### PR TITLE
Fixed git clone command in README to prevent repository not found error

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ services:
 
 Clone from github using:
 ```
-git clone https://github.com/xXxNIKIxXx/TimeSync--All4Schools-Schedule-Integration-.git
+git clone https://github.com/xXxNIKIxXx/TimeSync.git
 ```
 
 Create a compose.yml file:


### PR DESCRIPTION
Git clone command returns error, remote repository not found. Updated link to fix the issue.